### PR TITLE
Исправляет бесконечную рекурсию

### DIFF
--- a/src/Maximaster/Tools/Orm/Iblock/ElementTable.php
+++ b/src/Maximaster/Tools/Orm/Iblock/ElementTable.php
@@ -122,7 +122,9 @@ class ElementTable extends \Bitrix\Iblock\ElementTable implements IblockRelatedT
                         $entityName = '\\' . __CLASS__;
                         if ($prop['LINK_IBLOCK_ID'])
                         {
-                            $entityName = self::compileEntity($prop['LINK_IBLOCK_ID'])->getDataClass();
+	                        $entityName = $iblockId == $prop['LINK_IBLOCK_ID']
+		                        ? get_called_class()
+		                        : self::compileEntity($prop['LINK_IBLOCK_ID'])->getDataClass();
                             $valueReference['=ref.IBLOCK_ID'] = new SqlExpression('?i', $prop['LINK_IBLOCK_ID']);
                         }
 


### PR DESCRIPTION
Когда в ИБ есть свойство с привязкой с этому же ИБ, `\Maximaster\Tools\Orm\Iblock\ElementTable::compileEntity()` падает от рекурсии.